### PR TITLE
make itm optional to allow usage on Cortex-M0 microcontrollers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ optional = true
 [features]
 semihosting = ["cortex-m-semihosting"]
 log-integration = ["log"]
+itm = []
 
 [package.metadata.docs.rs]
 features = ["semihosting", "log-integration"]

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Logging facilities for Cortex-M processors
 
 - `log-integration` - Enables [log](https://github.com/rust-lang-nursery/log) integration
 - `semihosting` - Enables facilities for [cortex-m-semihosting](https://github.com/japaric/cortex-m-semihosting).
+- `itm` - Enables ITM destination for logging (not available on Cortex-M0 microcontrollers)

--- a/src/destination/mod.rs
+++ b/src/destination/mod.rs
@@ -7,7 +7,9 @@
 pub mod dummy;
 pub use self::dummy::Dummy;
 
+#[cfg(feature = "itm")]
 pub mod itm;
+#[cfg(feature = "itm")]
 pub use self::itm::Itm;
 
 #[cfg(feature = "semihosting")]

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -34,7 +34,9 @@ pub trait Printer {
 pub mod dummy;
 pub use self::dummy::Dummy;
 
+#[cfg(feature = "itm")]
 pub mod itm;
+#[cfg(feature = "itm")]
 pub use self::itm::Itm;
 
 #[cfg(feature = "semihosting")]


### PR DESCRIPTION
Hey,

by making ITM optional it is possible to use your library with semihosting on Cortex-M0 microcontrollers.

Greetings, Joost