### PR TITLE
ITM Sync with mutex

### DIFF
--- a/src/destination/itm.rs
+++ b/src/destination/itm.rs
@@ -1,33 +1,42 @@
 //! ITM module
 
-use cortex_m::{itm};
+use cortex_m::{itm, interrupt::Mutex};
 use core::fmt;
+
+use core::cell::RefCell;
 
 /// ITM based destination
 pub struct Itm {
-    inner: cortex_m::peripheral::ITM,
+    inner: Mutex<RefCell<cortex_m::peripheral::ITM>>,
 }
 
 impl Itm {
     /// Creates new instance by taking ownership of ITM register block
     pub fn new(itm: cortex_m::peripheral::ITM) -> Self {
-        Self { inner: itm }
+        Self { inner: Mutex::new(RefCell::new(itm)) }
     }
 }
 
 impl fmt::Write for Itm {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let stim = &mut self.inner.stim[0];
-        itm::write_str(stim, s);
-
+        cortex_m::interrupt::free(|cs| {
+            if let Some(mut itm) = self.inner.borrow(cs).try_borrow_mut().ok() {
+                let stim = &mut itm.stim[0];
+                itm::write_str(stim, s);
+            }
+        });
         Ok(())
     }
 
     #[inline]
     fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
-        let stim = &mut self.inner.stim[0];
-        itm::write_fmt(stim, args);
+        cortex_m::interrupt::free(|cs| {
+            if let Some(mut itm) = self.inner.borrow(cs).try_borrow_mut().ok() {
+                let stim = &mut itm.stim[0];
+                itm::write_fmt(stim, args);
+            }
+        });
 
         Ok(())
     }


### PR DESCRIPTION
This PR addresses #2 .

Basically puts the itm behind a cortex-m mutex which then gets unlocked inside a critical sections.