### PR TITLE
Dummy printer should not panic

### DIFF
--- a/src/printer/dummy.rs
+++ b/src/printer/dummy.rs
@@ -3,7 +3,16 @@
 use core::fmt;
 
 /// Dummy printer
-pub struct Dummy;
+pub struct Dummy {
+    w: crate::destination::Dummy,
+}
+
+impl Dummy {
+    /// Create dummy printer
+    pub fn new() -> Self {
+        Dummy { w: crate::destination::Dummy }
+    }
+}
 
 impl super::Printer for Dummy {
     type W = crate::destination::Dummy;
@@ -11,7 +20,7 @@ impl super::Printer for Dummy {
 
     #[inline]
     fn destination(&mut self) -> &mut Self::W {
-        unreachable!()
+        &mut self.w
     }
 
     #[inline]


### PR DESCRIPTION
Return Dummy destination/writer instead of panicking from Dummy
printer.

Users may use Printer or Destination (via `.destination()`)
interchangeably, so Dummy printer should not panic in that case.