### PR TITLE
Feature: unsafely make itm sync, at the cost of correctness.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ optional = true
 semihosting = ["cortex-m-semihosting"]
 log-integration = ["log"]
 itm = []
+unsafe-itm = ["itm"]
 
 [package.metadata.docs.rs]
-features = ["semihosting", "log-integration", "itm"]
+features = ["semihosting", "log-integration", "itm", "unsafe-itm"]

--- a/src/printer/itm.rs
+++ b/src/printer/itm.rs
@@ -74,8 +74,10 @@ impl<Mode: InterruptModer> super::Printer for ItmSync<Mode> {
     }
 }
 
-unsafe impl<Mode: InterruptModer> Sync for ItmSync<Mode> {
-}
+unsafe impl<Mode: InterruptModer> Sync for ItmSync<Mode> {}
+
+#[cfg(feature = "unsafe-itm")]
+unsafe impl<Mode: InterruptModer> Sync for Itm<Mode> {}
 
 /// Alias for Interrupt free Printer
 pub type InterruptFree = Itm<crate::modes::InterruptFree>;


### PR DESCRIPTION
This features allows a user to *opt-in* to unsafely making `Itm` `Sync`. This sacrifices the correctness of the log output, for performance. Disabling all interrupts to log a message via the Itm cripples performance in a real time system.